### PR TITLE
Quill UI Improvements

### DIFF
--- a/src/main/webapp/Feed_Page.jsp
+++ b/src/main/webapp/Feed_Page.jsp
@@ -108,6 +108,12 @@ font-size: 90%;
 .ql-container.ql-snow {
     border: 0px solid #ccc;
 }
+
+.ql-snow .ql-editor img {
+    max-width: 50%;
+    max-height: 50%;
+}
+
     </style>
 </head>
 
@@ -365,6 +371,7 @@ font-size: 90%;
 																								if(typeof del.insert!=='object' && count1==1)
 																								{
 																									count1=0;
+																									content=content+del.insert.substr(1,del.insert.length);
 																									continue;
 																								}
 																								

--- a/src/main/webapp/Question_Page.jsp
+++ b/src/main/webapp/Question_Page.jsp
@@ -114,6 +114,7 @@ font-size: 90%;
 
 .ql-snow .ql-editor img {
     max-width: 50%;
+    max-height: 50%;
 }
     </style>
  

--- a/src/main/webapp/Question_Search.jsp
+++ b/src/main/webapp/Question_Search.jsp
@@ -164,8 +164,8 @@ else if(utype.equals("faculty"))
 }
 
 img.resize {
-  max-width:25%;
-  max-height:25%;
+  max-width:15%;
+  max-height:15%;
   float: right;
 }
 
@@ -196,7 +196,9 @@ font-size: 90%;
 
 .ql-snow .ql-editor img {
     max-width: 50%;
+    max-height: 50%;
 }
+
 
     </style>
 </head>
@@ -361,12 +363,7 @@ font-size: 90%;
                                                                                         <script>
                                                                        
                                                                                             
-                                                                                        quillque.setContents(<%= qm.getMostUpvotedAnswer() %>); 
-                                                                                        var htmlcontent=quillque.root.innerHTML;
-                                                                                        var c=document.getElementsByClassName("ans");
-                                                                                        c[<%=i%>].innerHTML=htmlcontent;
-//                                                                                        console.log(htmlcontent);
-                                        									
+                                                            
                                         									if(!isNoOne)
                                         									{
                                         										quillAnswers.push(<%= qm.getMostUpvotedAnswer() %>);
@@ -394,15 +391,24 @@ font-size: 90%;
                                         								
                                         									if(typeof del.insert!=='object' && count1==1)
                                         									{
+                                        										console.log(del.insert);
+                                        										console.log("-->"+i);
+                                        										content=content+del.insert.substr(1,del.insert.length);
                                         										count1=0;
                                         										continue;
                                         									}
                                         									
                                         									if(typeof del.insert!=='object')
+                                        									{
+                                        										console.log(del.insert);
+                                        										console.log("////////"+i);
                                         										content=content+del.insert;
+                                        									}
                                         									
                                         									else if(count==0)
                                         									{
+                                        										console.log(del.insert);
+                                        										console.log("@@@@@"+i);
                                         										count++;
                                         										imgObj=del.insert;
                                         										count1=1;

--- a/src/main/webapp/Workspace_Page.jsp
+++ b/src/main/webapp/Workspace_Page.jsp
@@ -154,7 +154,8 @@ font-size: 90%;
 }
 
 .ql-snow .ql-editor img {
-    max-width: 50%;
+    max-width: 35%;
+    max-height: 35%;
 }
 
     </style>
@@ -449,7 +450,7 @@ font-size: 90%;
 									{
 										quillAnswers.push({"ops":[{"insert":""}]});
 										document.getElementsByClassName("read")[<%=i%>].innerHTML="";
-										isNoOne=false;
+										isFullShow.push(false);
 									}
 									
                                 quillque.setContents(<%= qm.getMostUpvotedAnswer() %>); 
@@ -466,6 +467,7 @@ font-size: 90%;
 									if(typeof del.insert!=='object' && count1==1)
 									{
 										count1=0;
+										content=content+del.insert.substr(1,del.insert.length);
 										continue;
 									}
 									

--- a/src/main/webapp/myprofile.jsp
+++ b/src/main/webapp/myprofile.jsp
@@ -117,6 +117,12 @@ font-size: 90%;
 .ql-container.ql-snow {
     border: 0px solid #ccc;
 }
+
+.ql-snow .ql-editor img {
+    max-width: 50%;
+    max-height: 50%;
+}
+
     </style>
     
      
@@ -430,7 +436,7 @@ font-size: 90%;
 																							{
 																								quillAnswers.push({"ops":[{"insert":""}]});
 																								document.getElementsByClassName("read")[<%=i%>].innerHTML="";
-																								isNoOne=false;
+																								isFullShow.push(false);
 																							}
                                                                                             quillque.setContents(<%= qm.getMostUpvotedAnswer() %>); 
                                                                                             window.delta=quillque.getContents();
@@ -446,6 +452,7 @@ font-size: 90%;
 																								if(typeof del.insert!=='object' && count1==1)
 																								{
 																									count1=0;
+																									content=content+del.insert.substr(1,del.insert.length);
 																									continue;
 																								}
 																								

--- a/src/main/webapp/profilepage.jsp
+++ b/src/main/webapp/profilepage.jsp
@@ -118,6 +118,12 @@ font-size: 90%;
     border: 0px solid #ccc;
 }
 
+.ql-snow .ql-editor img {
+    max-width: 50%;
+    max-height: 50%;
+}
+
+
     </style>
     
      
@@ -132,6 +138,7 @@ font-size: 90%;
          
          var isNoOne=false;
          var quillAnswers=[];
+         var isFullShow=[];
          
             var toolbarOptions =[
                 ['bold','italic','underline','strike'], 
@@ -229,6 +236,24 @@ font-size: 90%;
             quillque=new Quill('#editorque',configque);
             console.log("quillque"+quillque);            
         
+            var configForShow = {
+                    "theme": "snow",
+                    "modules": {
+                    "toolbar": false
+        				}
+                    
+        		};
+                var quillShowAns;
+                function instantiateEditor(i)
+                {
+                	ans=quillAnswers[i];
+                    quillShowAns=new Quill('#ans'+i,configForShow);
+                    quillShowAns.setContents(ans);
+                    quillShowAns.enable(false);  
+                    document.getElementsByClassName("ansImg")[i].innerHTML="";
+                    document.getElementsByClassName("read")[i].innerHTML="";
+                }
+            
         </script>
         
         
@@ -366,7 +391,7 @@ font-size: 90%;
 						            				<img src="ImageLoader?uid=<%= qm.getTopAnswerer() %>" alt="Circle Image" class="img-circle img-responsive" style="margin-left: 10px;">
 						            			</div>
 						            			<div class="col-md-11 col-sm-11" style="padding-left: 1px;">
-                                                                                   <%if(qm.getAnswererName().equals("No one")){%><a style="color: #0099cc;"> <%= qm.getAnswererName() %></a><script>isNoOne=true;</script><%}else{%><a href="UserProfile?uid=<%= qm.getTopAnswerer() %>" style="color: #0099cc;"> <%= qm.getAnswererName() %></a><%}%> answered
+                                                                                   <%if(qm.getAnswererName().equals("No one")){%><a style="color: #0099cc;"> <%= qm.getAnswererName() %></a><script>isNoOne=true; console.log("in isno one");</script><%}else{%><a href="UserProfile?uid=<%= qm.getTopAnswerer() %>" style="color: #0099cc;"> <%= qm.getAnswererName() %></a><%}%> answered
                                                                                    <br><span class="ansImg" ></span><div class="lead ans" style="margin-bottom: 1px;"></div>
 													<a class="read" href="#no" style="color: #0099cc;" onclick="instantiateEditor('<%=i%>')">Read more</a><br>
 													<!--  <a class="read" href="#no" style="color: #0099cc;" onclick="show('ans<%=i%>','read<%=i%>')">Read more</a> -->
@@ -381,7 +406,7 @@ font-size: 90%;
 																							{
 																								quillAnswers.push({"ops":[{"insert":""}]});
 																								document.getElementsByClassName("read")[<%=i%>].innerHTML="";
-																								isNoOne=false;
+																								isFullShow.push(false);
 																							}
                                                                                             quillque.setContents(<%= qm.getMostUpvotedAnswer() %>); 
                                                                                             window.delta=quillque.getContents();
@@ -396,6 +421,7 @@ font-size: 90%;
 																							
 																								if(typeof del.insert!=='object' && count1==1)
 																								{
+																									content=content+del.insert.substr(1,del.insert.length);
 																									count1=0;
 																									continue;
 																								}
@@ -427,11 +453,25 @@ font-size: 90%;
                                                                                             
                                                                                             var c=document.getElementsByClassName("ans");
                                                                                             
-                                                                                            if(content.length>250)
-    	                                                                                        c[<%=i%>].innerText=content.substr(0,250)+"...";
+                                                                                            if(content.length>100)
+                                                                                            {
+                                                                                            	c[<%=i%>].innerText=content.substr(0,100)+"...";
+                                                                                            	isFullShow.push(false);
+                                                                                            }
+                                                                                            else if(!isNoOne)
+                                                                                       		{
+                                                                                       			console.log("i am else");
+                                                                                       			console.log(content);
+                                                                                       			console.log("\n"+content.length);
+                                                                                       			c[<%=i%>].innerText=content;
+                                                                                       			isFullShow.push(true);
+                                                                                       		}
     		                                                                                    
     		                                                                                    else
-    		                                                                                    c[<%=i%>].innerText=content;
+    		                                                                                    {
+    		                                                                                    	isNoOne=false;
+    		                                                                                    	c[<%=i%>].innerText=content;
+    		                                                                                    }
                                                                                         </script>	
                                                                                 </div>
 						            		</div>
@@ -456,27 +496,15 @@ font-size: 90%;
             readElements[i].id = 'read' + i;
             ansElements[i].id = 'ans' + i;
         
+            if(isFullShow[i])
+            {
+            	instantiateEditor(i);
+            }
+        
          }
         
         
-        var configForShow = {
-            "theme": "snow",
-            "modules": {
-            "toolbar": false
-				}
-            
-		};
-        var quillShowAns;
-        function instantiateEditor(i)
-        {
-        	ans=quillAnswers[i];
-            quillShowAns=new Quill('#ans'+i,configForShow);
-            quillShowAns.setContents(ans);
-            quillShowAns.enable(false);  
-            document.getElementsByClassName("ansImg")[i].innerHTML="";
-            document.getElementsByClassName("read")[i].innerHTML="";
-        }
-    
+       
         </script><%}%>
 				                        </div>
 				                        <div class="tab-pane" id="work">


### PR DESCRIPTION
### Changes in this PR:

-  Whenever answer's length is less than 100 characters then that answer is displayed without **Read More** option in proper formatting.

- If the answer contains images and its length is more than 100 characters, then that answer is shown without formatting and up to 100 characters only and the first image of the answer is displayed at the right margin.

### Reference GitHub issues:
#16 

###Screenshots

![image](https://user-images.githubusercontent.com/17068346/37042883-5801b010-2185-11e8-87d0-be8aa3eba964.png)

![image](https://user-images.githubusercontent.com/17068346/37042912-67601272-2185-11e8-85a5-c487694c8a3f.png)

